### PR TITLE
allow template to also be a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ App.prototype.loadViews = function(filename, namespace) {
 };
 
 App.prototype._registerTemplate = function(template, namespace, filename) {
-  var file = template.innerHTML;
+  var file = typeof template === 'string' ? template : template.innerHTML;
   var app = this;
   function onImport(attrs) {
     var dir = path.dirname(filename);


### PR DESCRIPTION
This makes it easier to load templates with XHR: no need to turn the string into a DOM when `.innerHTML` is used right away anyway.